### PR TITLE
Switch to the requests embedded json

### DIFF
--- a/nutshell/__init__.py
+++ b/nutshell/__init__.py
@@ -1,4 +1,3 @@
-import json
 import requests
 import six
 from uuid import uuid4
@@ -40,7 +39,7 @@ class NutshellAPI(object):
             'id': self._generate_request_id(),
         }
 
-        response = self.session.post(url, data=json.dumps(payload))
+        response = self.session.post(url, json=payload)
 
         if response.status_code != 200:
             raise NutshellApiException('HTTP status %s while finding endpoint: %s' % (

--- a/tests/test_nutshell.py
+++ b/tests/test_nutshell.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-import json
 from uuid import uuid4
 import unittest
 import six
@@ -124,7 +123,7 @@ class TestAPIClient(unittest.TestCase):
         expected_payload = {'method': method,
                             'params': params,
                             'id': six.text_type(mock_id)}
-        mock_session.post.assert_called_with(url, data=json.dumps(expected_payload))
+        mock_session.post.assert_called_with(url, json=expected_payload)
         self.assertTrue(mock_response.json.called)
 
     @patch('nutshell.NutshellAPI._api_endpoint_for_user')


### PR DESCRIPTION
Since the required version of requests package is larger than 2.4.2, [simplified posting of json could be used](http://docs.python-requests.org/en/master/user/quickstart/#more-complicated-post-requests)
